### PR TITLE
Fix iOS PDF download

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -10,7 +10,29 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
   }
 
   const text = document.getElementById('textInput').value;
-  const lines = doc.splitTextToSize(text, 180);
-  doc.text(lines, 15, 20);
-  doc.save('metin.pdf');
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const lines = doc.splitTextToSize(text, pageWidth - 30);
+
+  let cursorY = 20;
+  const lineHeight = 10;
+
+  lines.forEach(line => {
+    if (cursorY > pageHeight - 20) {
+      doc.addPage();
+      cursorY = 20;
+    }
+    doc.text(line, 15, cursorY);
+    cursorY += lineHeight;
+  });
+
+  const blob = doc.output('blob');
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'metin.pdf';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 });


### PR DESCRIPTION
## Summary
- handle multi-page PDF generation with jsPDF
- force PDF download via blob URL instead of opening in-browser

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bddf2c638832ab1b198c71ec71891