### PR TITLE
Fix bullet and paragraph formatting in PDF export

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -12,18 +12,28 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
   const text = document.getElementById('textInput').value;
   const pageWidth = doc.internal.pageSize.getWidth();
   const pageHeight = doc.internal.pageSize.getHeight();
-  const lines = doc.splitTextToSize(text, pageWidth - 30);
 
+  const paragraphs = text.split(/\r?\n/);
   let cursorY = 20;
   const lineHeight = 10;
+  const paragraphSpacing = 5;
 
-  lines.forEach(line => {
-    if (cursorY > pageHeight - 20) {
-      doc.addPage();
-      cursorY = 20;
+  paragraphs.forEach(paragraph => {
+    if (paragraph.trim() === '') {
+      cursorY += paragraphSpacing;
+      return;
     }
-    doc.text(line, 15, cursorY);
-    cursorY += lineHeight;
+
+    const lines = doc.splitTextToSize(paragraph, pageWidth - 30);
+    lines.forEach(line => {
+      if (cursorY > pageHeight - 20) {
+        doc.addPage();
+        cursorY = 20;
+      }
+      doc.text(line, 15, cursorY);
+      cursorY += lineHeight;
+    });
+    cursorY += paragraphSpacing;
   });
 
   const blob = doc.output('blob');


### PR DESCRIPTION
## Summary
- preserve blank lines and bullet formatting
- add paragraph spacing while converting text to PDF

## Testing
- `node` (failed: Cannot find module 'jspdf')

------
https://chatgpt.com/codex/tasks/task_e_687bdfe5a250832ab427a3fcfe4090e1